### PR TITLE
Compatibility ggplot2 3.6.0

### DIFF
--- a/tests/testthat/test-plot_expirest_osle.R
+++ b/tests/testthat/test-plot_expirest_osle.R
@@ -103,11 +103,9 @@ test_that("plot_expirest_osle_succeeds", {
   expect_equal(tmp2[["vlines"]][, "Colour"], "forestgreen")
   expect_equal(tmp2[["vlines"]][, "Type"], "dotdash")
 
-  expect_length(tmp3[["Graph"]]$labels, 9)
   expect_equal(tmp3[["text"]][, "Label"],
                c("LSL: 94.95", "USL: 105.04", "23.7"))
 
-  expect_length(tmp4[["Graph"]]$labels, 6)
   expect_equal(tmp4[["text"]][, "Label"],
                c("LSL: 94.95", "USL: 105.04", "30.2"))
 

--- a/tests/testthat/test-plot_expirest_wisle.R
+++ b/tests/testthat/test-plot_expirest_wisle.R
@@ -231,7 +231,6 @@ test_that("plot_expirest_wisle_succeeds", {
   expect_equal(tmp2[["arrow"]][1, "Angle"], 90)
   expect_equal(tmp2[["arrow"]][1, "Length"], 5)
 
-  expect_length(tmp3stsc[["Graph"]]$labels, 11)
   expect_equal(tmp3stsc[["text"]][, "Label"],
                c("LSL: 94.95", "USL: 105.04", "98.405 ", "100.45",
                  "7.5\n(worst case\nscenario)", "23.7\n(standard\nscenario)",
@@ -239,7 +238,6 @@ test_that("plot_expirest_wisle_succeeds", {
   expect_equal(signif(tmp3stsc[["text"]][, "Month"], 5),
                c(29.000, 29.0000, 0.00000, 0.00000, 7.5187, 23.698, 29.000))
 
-  expect_length(tmp3wcsc[["Graph"]]$labels, 11)
   expect_equal(tmp3wcsc[["text"]][, "Label"],
                c("LSL: 94.95", "USL: 105.04", "98.405 ", "100.45",
                  "7.5\n(worst case\nscenario)", "23.7\n(standard\nscenario)",
@@ -247,26 +245,21 @@ test_that("plot_expirest_wisle_succeeds", {
   expect_equal(signif(tmp3wcsc[["text"]][, "Month"], 5),
                c(10.000, 10.0000, 0.00000, 0.00000, 7.5187, 23.698, 10.000))
 
-  expect_length(tmp4[["Graph"]]$labels, 8)
   expect_equal(tmp4[["text"]][, "Label"],
                c("LSL: 94.95", "USL: 105.04", "99.861 ", "101.91",
                  "8.3\n(worst case\nscenario)", "30.2\n(standard\nscenario)",
                  "LRL: 96.995"))
-  expect_length(tmp4l1[["Graph"]]$labels, 8)
   expect_equal(tmp4l1[["text"]][, "Label"],
                c("LSL: 94.95", "USL: 105.04", "99.861 ", "101.91",
                  "8.3\n(worst case\nscenario)", "30.2\n(standard\nscenario)",
                  "LRL: 96.995"))
-  expect_length(tmp4l2[["Graph"]]$labels, 8)
   expect_equal(tmp4l2[["text"]][, "Label"],
                c("LSL: 94.95", "USL: 105.04", "99.861 ", "101.91",
                  "8.3", "30.2", "LRL: 96.995"))
-  expect_length(tmp4b1[["Graph"]]$labels, 5)
   expect_equal(tmp4b1[["text"]][, "Label"],
                c("LSL: 94.95", "USL: 105.04", "99.861 ", "101.91",
                  "8.3\n(worst case\nscenario)", "30.2\n(standard\nscenario)",
                  "LRL: 96.995"))
-  expect_length(tmp4b2[["Graph"]]$labels, 5)
   expect_equal(tmp4b2[["text"]][, "Label"],
                c("LSL: 94.95", "USL: 105.04", "99.861 ", "101.91",
                  "8.3\n(worst case\nscenario)", "30.2\n(standard\nscenario)",


### PR DESCRIPTION
Hi there,

Apologies for not posting an issue first.
The ggplot2 package is planning an update for around May 2025 and a reverse dependency test identified a problem with the agricolaeplotr package.
The details are explained in https://github.com/tidyverse/ggplot2/issues/6290, but essentially ggplot2 doesn't populate the `plot$labels` field before plot building anymore, which violates some test assumptions in this package.

The tests that were checking for the length of the `labels` field were fragile (easy to break by even mild upstream changes), so this PR removes them.
You can test the changes yourself with the development version of ggplot2 (`pak::pak("tidyverse/ggplot2")`)

Best,
Teun